### PR TITLE
Use the current working directory for reading and writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Resulting you get an HTML file that contains everything needed, so you can host 
 node convert.js MyPageTitle
 ```
 
+This will read the `README.md` from your current working directory and output the resulting HTML as `README.html` in the same directory.
+
 ## Open tasks
 
 Check out the [open issues](https://github.com/KrauseFx/markdown-to-html-github-style/issues), in particular code blocks currently don't support syntax highlighting, however that's something that's rather easy to add. For a minimalistic stylesheet we could take the styles from [krausefx.com css](https://github.com/KrauseFx/krausefx.com/blob/021186e228e183904af68ad8fc500c35107f00ae/assets/main.scss#L345-L438).

--- a/convert.js
+++ b/convert.js
@@ -4,7 +4,7 @@ let filename = "README.md"
 let pageTitle = process.argv[2] || ""
 
 fs.readFile(__dirname + '/style.css', function (err, styleData) {
-  fs.readFile(__dirname + '/' + filename, function (err, data) {
+  fs.readFile(process.cwd() + '/' + filename, function (err, data) {
     if (err) {
       throw err; 
     }
@@ -38,9 +38,13 @@ fs.readFile(__dirname + '/style.css', function (err, styleData) {
     converter.setFlavor('github');
     console.log(html);
 
-    let filePath = __dirname + "/index.html";
-    fs.writeFile(filePath, html, function(err) { 
-      console.log("Done, saved to " + filePath);
-    }); 
+    let filePath = process.cwd() + "/README.html";
+    fs.writeFile(filePath, html, { flag: "wx" }, function(err) {
+      if (err) {
+        console.log("File '" + filePath + "' already exists. Aborted!");
+      } else {
+        console.log("Done, saved to " + filePath);
+      }
+    });
   });
 });

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
 <h2 id="usage">Usage</h2>
 <pre><code>node convert.js MyPageTitle
 </code></pre>
+<p>This will read the <code>README.md</code> from your current working directory and output the resulting HTML as <code>README.html</code> to the same directory.</p>
 <h2 id="open-tasks">Open tasks</h2>
 <p>Check out the <a href="https://github.com/KrauseFx/markdown-to-html-github-style/issues">open issues</a>, in particular code blocks currently don't support syntax highlighting, however that's something that's rather easy to add. For a minimalistic stylesheet we could take the styles from <a href="https://github.com/KrauseFx/krausefx.com/blob/021186e228e183904af68ad8fc500c35107f00ae/assets/main.scss#L345-L438">krausefx.com css</a>.</p>
 <h2 id="playground-to-test">Playground to test</h2>
@@ -150,7 +151,7 @@
   }
 
   body > #content {
-    padding: 0px 20px !important;
+    padding: 0px 20px 20px 20px !important;
   }
 }
 
@@ -163,6 +164,16 @@ body > #content {
   border-radius: 2px;
   margin-left: auto;
   margin-right: auto;
+}
+
+hr {
+  color: #bbb;
+  background-color: #bbb;
+  height: 1px;
+  flex: 0 1 auto;
+  margin: 1em 0;
+  padding: 0;
+  border: none;
 }
 
 /**


### PR DESCRIPTION
Write a `README.html` file instead of `index.html`.
Don't overwrite existing files.

Fixes https://github.com/KrauseFx/markdown-to-html-github-style/issues/12