### PR TITLE
Add charset meta tag to correctly render special characters after conversion to HTML

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -21,6 +21,7 @@ fs.readFile(__dirname + '/style.css', function (err, styleData) {
     <html>
       <head>
         <title>` + pageTitle + `</title>
+        <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
       </head>
       <body>


### PR DESCRIPTION
Currently special chars like ' or ™ are not rendered correctly in HTML.